### PR TITLE
switching provider from 'firebase' to 'default'

### DIFF
--- a/src/firebase-connect/index.ts
+++ b/src/firebase-connect/index.ts
@@ -80,7 +80,7 @@ export default defineEndpoint({
 							}
 						},
 						email_verified: decodedToken.email_verified,
-						provider: 'firebase',
+						provider: 'default',
 						phone_number_verified: false,
 						external_identifier: decodedToken.uid, // Save Firebase UID if needed
 					});


### PR DESCRIPTION
Using `firebase` as a provider doesn't seem appropriate since it's not actually used to log into the directus app. I switched it to `default` so this could work out of the box.